### PR TITLE
Updated Travis YML to use 7.1 simulator target.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 xcode_workspace: Tesseract-OCR-iOS.xcworkspace
 xcode_sdk:
-    - iphonesimulator7.0
+    - iphonesimulator7.1
     - iphonesimulator8.1 
 xcode_scheme: 
     - Template Framework Project


### PR DESCRIPTION
_Note: If you accept this pull request here to your fork, then this commit to (hopefully) fix the build on Travis should automatically show up in your #158 pull request on the main Tesseract iOS repo._

I'm in contact with Travis CI support and they told me that the
new version of Xcode installed on Travis does not have the
`iphonesimulator7.0` target anymore; instead it now has an
`iphonesimulator7.1` target, but they're having an issue with
it being available right now. In the mean time, I'm updating
our build matrix here so when they fix the issue on their end
we can just re-run our build to have it pass. Here's the message
I received from a Travis rep:

"The 7.0 SDK was removed in Xcode 6.1.1. 7.1 should've been
installed, but for some reason wasn't, so we rolled it back.
Looks like the new image got rolled out again for some reason,
I'm investigating now."
